### PR TITLE
Updates to How We Work with other teams to develop modules

### DIFF
--- a/11-module-development.md
+++ b/11-module-development.md
@@ -1,0 +1,73 @@
+# Module Development
+
+Newfold modules are self-contained pieces of functionality that can be used to extend the functionality of a brand
+plugin. Modules are developed in their own repositories and are installed as dependencies of brand plugins.
+
+## Expectations
+
+- A single team will be responsible for the development and maintenance of a specific module. This team is referred
+  to as the "module owners".
+- The module owners are responsible for requesting an architectural review from the WordPress COE team in the early
+  stages of any new development.
+- The module owners are responsible for following
+  the [GitFlow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) branching model
+  and [semantic versioning](https://semver.org/) when
+  developing and releasing the module.
+- The module owners are responsible for overseeing all code reviews and releases within their module repository.
+- The module owners are responsible for writing tests for all new functionality and updating tests for existing
+  functionality. Currently, these tests are to live in the brand plugin repositories.
+- The module owners are responsible for creating and testing **pre-releases** of the brand plugins that use the module.
+- When the module owners determine that a module release and brand plugin pre-release is ready for production, it is
+  their responsibility to create a PR against the brand plugin's `develop` branch to update the module version.
+
+## Workflow
+
+The following is a high-level overview of the workflow for developing and releasing a module.
+
+### Pre-Development
+
+- The module owners should request that the WordPress COE team create a repository for your module in the Newfold
+  Labs GitHub organization.
+- The module repository should be scaffolded before development starts. This can be done by the module owners or the
+  WordPress COE team.
+- The module owners will need to request that the WordPress COE team add any GitHub secrets to the module repository
+  in order to use the GitHub Actions workflows.
+- The module owners will need to request an [architectural review](13-architectural-reveiw.md) from the WordPress COE team before a new module
+  is allowed to be released.
+- After a successful architectural review, the module owners follow the development flow in the next section.
+
+### Development
+
+1. Do all development work in feature branches in the module repository, following the branch naming conventions on the
+   [Version Control](9-version-control.md#branch-naming) page. Be sure to start all feature branches from the
+   `develop` branch.
+2. Create a pull request against the `develop` branch in the module repository when a feature branch is ready for
+   review, and merge it only when automated checks pass and at least one other developer approves it.
+3. Once all features are in the `develop` branch, start preparing for a release.
+4. Create a release branch from the `develop` branch, following the branch naming conventions in
+   the [Version Control](9-version-control.md#branch-naming) page.
+5. Tag a pre-release version (e.g. `1.0.0-rc.1`) on the module repository.
+6. Test the pre-release locally.
+7. Create a feature branch on any applicable brand plugin repositories, update the module version to the pre-release
+   version, implement any additional integrations, and verify proper coverage via automated tests.
+8. Tag a pre-release on the brand plugin repository (e.g. `1.0.0-alpha.1`) for your feature branch, and test the alpha
+   release using the build created via GitHub Actions. **Be sure to check the "Set as a pre-release" checkbox when
+   creating the release!**
+9. If issues are found in the module, create a new PR against the release branch in the module repo with any required
+   fixes, repeat steps 5-8 and be sure to increment the release candidate version.
+10. If issues are specific to the brand plugin, apply any fixes to the feature branch in the brand plugin repo and
+    repeat steps 8-9, making sure to increment the pre-release version.
+11. If no issues are found, merge the release branch in the module repository into the `main` branch, tag a new
+    production release (e.g. `1.0.0`) and update the feature branch in the brand plugin(s) to use the new release.
+12. Create a new pull request from the feature branch in the brand plugin against the `develop` branch. Select at
+    least 2 members of the WordPress COE team as reviewers, and notify the WordPress COE team in the `General`
+    channel of the `Press 1, 2, 4 Coordination` team in Microsoft Teams.
+
+At this point, your PR has been officially submitted. Code must be submitted by Wednesday the week before a
+release is scheduled to go out in order to make it into that release. If any issues are found, the WordPress COE
+team may request changes to the PR. If the PR is not ready to be merged by the end of the week, it will be pushed
+to the next release.
+
+Keep in mind that the WordPress COE team will **NOT** conduct a full code review of the PR unless you specifically
+request it. However, they will review the PR for any obvious issues such as failing tests, missing tests, missing
+documentation, failing or missing GitHub Action checks, etc.

--- a/12-tests.md
+++ b/12-tests.md
@@ -1,0 +1,23 @@
+# Tests
+
+## Types of Testing
+
+### Unit Tests
+
+We utilize PHPUnit for unit testing. Where applicable, unit tests should be written for all new code, or updated
+for existing code, by the team developing the functionality or making the change.
+
+### Component Tests
+
+Cypress should be used for component-based testing of React components. Where applicable, component tests should be
+written for all new code, or updated for existing code, by the team developing the functionality or making the change.
+
+### End-to-End Tests
+
+Cypress should be used for end-to-end testing of the WordPress environment. Where applicable, end-to-end tests should be
+written for all new code, or updated for existing code, by the team developing the functionality or making the change.
+
+## Best Practices
+
+When writing end-to-end tests, test functionality not code. For example, "This page is the color I expect and all 
+text is visible", NOT "this page has the CSS class I expect".

--- a/13-architectural-reveiw.md
+++ b/13-architectural-reveiw.md
@@ -1,0 +1,56 @@
+# Architectural Review
+
+An architectural review of code typically includes an assessment of the overall design and structure of the codebase, as well as its adherence to established architectural principles and patterns. Specific areas that may be reviewed include:
+
+- **Code organization:** The review will assess how the codebase is organized, such as the structure of the file and 
+folder hierarchy, the naming conventions used, and the use of appropriate abstractions and design patterns.
+
+- **Performance:** The review will assess how well the codebase is optimized for performance, such as the use of 
+appropriate data structures and algorithms, and the avoidance of performance bottlenecks.
+
+- **Scalability:** The review will assess how well the codebase is designed to scale and handle increased load, such as 
+the use of appropriate caching and indexing strategies, and the ability to handle a large number of concurrent requests.
+
+- **Security:** The review will assess the security of the codebase, such as the use of appropriate encryption and 
+authentication methods, the handling of sensitive data, and the avoidance of common security vulnerabilities.
+
+- **Maintainability:** The review will assess how easy the codebase is to maintain, such as the use of appropriate 
+documentation and comments, the use of consistent coding conventions, and the ease of locating and modifying code.
+
+- **Testing:** The review will assess the quality of the automated tests that are present in the codebase, such as the 
+coverage of tests, the use of appropriate testing frameworks, and the quality of test assertions.
+
+- **Modularity and Reusability:** The review will assess how well the codebase is designed to be modular and reusable, 
+such as the use of appropriate interfaces, the separation of concerns, and the ease of integration with other systems.
+
+- **Compliance:** The review will assess how well the codebase adheres to relevant standards, regulations and best 
+  practices.
+
+- **Technical debt:** The review will assess the technical debt of the codebase, such as the presence of legacy code, the 
+use of deprecated libraries and technologies, and the need for refactoring.
+
+## Preparing for an Architectural Review
+
+Before an architectural review, it is important to have written documentation of the codebase that can be used as a reference during the review. 
+
+This documentation should include:
+
+- A high-level overview of the module's intended functionality.
+- A high-level overview of the module's architecture. This should include a diagram of the module's classes and
+their relationships to each other. It should also include a diagram of the module's data flow.
+- A list of any direct dependencies that the module will have (e.g. Composer or NPM packages).
+- A list of any other modules that the module will depend on or interact with, if any.
+- A list of any plugins that the module will be used in (e.g. Bluehost plugin, HostGator plugin, etc).
+- A list of any expected data dependencies. For example, is certain data from the hosting platform, WordPress, or
+another module expected to be present? If so, what data is required and how will it be used? What happens if
+the data isn't there?
+- A list of any data that will be stored by the module. What is the data needed for and how will it be stored?
+Will the data be cached? If so, how long will it be cached for?
+- A list of any APIs that will be consumed or provided by the module. Provide the API endpoint names and URLs.
+What are the expected inputs and outputs? Will the responses be cached? If so, how long will they be cached for?
+- A list of any expected security considerations.
+- A list of any expected performance considerations.
+- A list of any expected privacy considerations.
+- A list of any expected accessibility considerations.
+- A list of any expected internationalization considerations.
+- A list of any events that will be sent to the Hiive.

--- a/5-wordpress.md
+++ b/5-wordpress.md
@@ -4,11 +4,12 @@ We're proud to help millions of customers get online with WordPress.
 
 ## Minimum Supported Versions
 
-_Last updated: March 2022_
+_Last updated: January 2023_
 
 ### WordPress Core
 
-We officially support the last two major releases of WordPress in our products. We always strive for more and expect products to gracefully degrade whenever possible, prompting users to update.
+We officially support the last three major releases of WordPress in our products. We always strive for more and expect 
+products to gracefully degrade whenever possible, prompting users to update.
 
 _Major releases of WordPress are 5.6, 5.7, 5.8 not WordPress 3.x or WordPress 4.x._
 
@@ -25,7 +26,7 @@ Generally we support:
 
 WordPress provides recommendations and minimums.
 
-At writing (April 2022), WordPress recommends PHP 7.4 and supports 5.6.20+.
+At writing (January 2023), [WordPress recommends](https://wordpress.org/about/requirements/) PHP 7.4 and supports 5.6.20+.
 
 We currently support two point releases below WordPress' recommendation -- all our products must work 100% two point releases below the recommendation.
 

--- a/7-philosophy.md
+++ b/7-philosophy.md
@@ -11,7 +11,7 @@ A key part of our team culture is to always be learning. Our team strives to alw
 
 ### User-centric engineering
 
-Our motivations for writing code should always start with the end user. What are their motiviations? What are their goals? What are their concerns? How can we best empower end users and get out of their way?
+Our motivations for writing code should always start with the end user. What are their motivations? What are their goals? What are their concerns? How can we best empower end users and get out of their way?
 
 Kind of like Human-Oriented Design, but for software.
 
@@ -25,7 +25,7 @@ In general, code in the simplest way not the coolest or cleverist way. Aim to sh
 
 ### Balance repetition and reuse
 
-There is a fine balance between chosing to repeat simple code and building reusable abstractions.
+There is a fine balance between choosing to repeat simple code and building reusable abstractions.
 
 Use good judgement for when to create utilities and abstractions that keep code uniform and maintainable, increase quality and expedite development. 
 
@@ -37,8 +37,8 @@ We have concrete performance practices for different kinds of code, but it is al
 
 Due to the distributed or high-traffic nature of many of our codebases, micro-optimizations add up in scale and over time. The flip side of that coin is that unoptimized, unminified and unnecessary assets exponentially eat away at storage and bandwidth as our userbases scale.
 
-We don't optimize just for optimization sake, but we look for opportunities to prioritize our resources and give time back to users.
+We don't optimize just for optimization's sake, but we look for opportunities to prioritize our resources and give time back to users.
 
 ### Legacy code is value code
 
-Old code isn't inheriently bad code. Old code has stood the test of time and created value for users and value for the organization. It may not be a foundation we can extend or build more off of, but that doesn't mean it wasn't good code when it was written and valuable code today.
+Old code isn't inherently bad code. Old code has stood the test of time and created value for users and value for the organization. It may not be a foundation we can extend or build more off of, but that doesn't mean it wasn't good code when it was written and valuable code today.

--- a/9-version-control.md
+++ b/9-version-control.md
@@ -1,6 +1,6 @@
 # Version Control
 
-We use [Git](https://git-scm.com/) to manage our code and we
+We use [Git](https://git-scm.com/) to manage our code and
 use [GitFlow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) as our workflow.
 
 ## Branch Naming
@@ -17,23 +17,25 @@ For each branch type defined by GitFlow, the following branch naming patterns ar
 
 ## Releases and Pre-Releases
 
-All production releases should be tagged by the WordPress COE team. Pre-releases can be tagged by anyone, but
-**MUST** be
-[marked on GitHub as a pre-release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#:~:text=To%20notify%20users%20that%20the%20release%20is%20not%20ready%20for%20production%20and%20may%20be%20unstable%2C%20select%20This%20is%20a%20pre%2Drelease.)
-.
+All production releases for brand plugins should be tagged by the WordPress COE team. Module releases and brand 
+plugin pre-releases can be tagged by anyone, but **MUST** be
+[marked on GitHub as a pre-release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#:~:text=To%20notify%20users%20that%20the%20release%20is%20not%20ready%20for%20production%20and%20may%20be%20unstable%2C%20select%20This%20is%20a%20pre%2Drelease.).
+
+Failure to properly name and mark a release as a pre-release can result in the release being automatically deployed 
+to production.
 
 ### Tagging
 
 Release version tags should adhere to [semantic versioning](https://semver.org/) an only be tagged on the applicable
 branches:
 
-| Tag | Branch | Examples |
-| --- | --- | --- |
-| X.Y.Z | `main` | `1.2.0` |
-| x.y.Z-rc.N | `hotfix/1.2.1` | `1.2.1-rc.1`, `1.2.1-rc.2` |
-| X.Y.z-rc.N | `release/1.2.0` | `1.2.0-rc.1` `1.2.0-rc.2` |
-| X.Y.Z-alpha.N | `develop` | `1.2.2-alpha.1`, `1.2.2-alpha.2` |
-| X.Y.Z-beta.N | `develop` | `1.2.2-beta.1`, `1.2.2-beta.2` |
+| Tag | Branch                   | Examples |
+| --- |--------------------------| --- |
+| X.Y.Z | `main`, `master`, `trunk` | `1.2.0` |
+| x.y.Z-rc.N | `hotfix/1.2.1`           | `1.2.1-rc.1`, `1.2.1-rc.2` |
+| X.Y.z-rc.N | `release/1.2.0`          | `1.2.0-rc.1` `1.2.0-rc.2` |
+| X.Y.Z-alpha.N | `develop`                | `1.2.2-alpha.1`, `1.2.2-alpha.2` |
+| X.Y.Z-beta.N | `develop`                | `1.2.2-beta.1`, `1.2.2-beta.2` |
 
 Capital letters represent the numbers that are changeable. Lowercase letters represent the numbers that are fixed.
 
@@ -50,13 +52,18 @@ Capital letters represent the numbers that are changeable. Lowercase letters rep
 
 ## Code Review & Release Restrictions
 
-- All code merged into the `main` branch for any repository must be done as a pull request which is to be reviewed by
-  the WordPress COE team.
+- All teams will handle code reviews and releases internally for any repositories they are responsible for.
+- All teams can request a code review from the WordPress COE team at any time. 
+- All teams are expected to request an architectural review from the WordPress COE team in the early stages of any 
+  new development.
 - All code merged into the `develop` branch of any repository must be done as a pull request which is to be reviewed by
-  at least one other member of the team.
-- All releases on the `main` branch for any repository must be handled by the WordPress COE team.
-- All releases on the `develop`, `release/*`, or `hotfix/*` branches can be done by anyone at any time as long as the
-  proper conventions are followed.
+  at least one other member from the same team.
+- All releases on the `main` branch for **brand plugins** must be handled by the WordPress COE team.
+- All releases on the `main` branch for **modules** must be handled by the team that owns the module.
+- All **pre-releases** on the `develop`, `release/*`, or `hotfix/*` branches can be done by anyone on 
+  any repository as long as the proper conventions are followed.
+- Tests should be written for all new code, or updated for existing code, by the team developing the functionality 
+  or making the change.
 - No pull requests are to be merged until it has:
     - At least one code review
     - All tests pass


### PR DESCRIPTION
Add documentation for other teams on the expected workflow and responsibilities associated with owning and releasing modules in the context of WordPress plugins.