### PR TITLE
add section detailing plugin and module directories in the context of…

### DIFF
--- a/10-releases.md
+++ b/10-releases.md
@@ -2,8 +2,12 @@
 
 ## Cadence
 
-- We will do a new release every two weeks on Wednesdays. 
-- Code must be in a PR the Wednesday before the release date to be considered.
+- We will issue new release on Wednesdays every other week (refer to the release calendar for specific releases).
+- Updates must be included in a PR the Wednesday before the scheduled release date to be considered.
+    - The PR should include a description of the updates and instructions for testing.
+    - The PR should preferably include updated tests (see [Tests](12-tests.md) page for more) to document these updates, or at least a video showing the updates.
+    - When creating the PR branch in the plugin repo so the github workflows function properly (packages can install and tests can run).
+    - A PR with no description or test coverage is not able to be merged.
 
 ## Compatability
 

--- a/12-tests.md
+++ b/12-tests.md
@@ -27,6 +27,8 @@ This marks a departure from the previous practice where all tests were located i
 
 Furthermore, this change brings us closer to the long-term goal of having workflows within the module to run tests before tagging a release. For the time being, it's important to ensure that tests pass locally before tagging a release, so we avoid a series of module releases solely to achieve passing tests in the plugin.
 
+Where possible, new features and bug fixes should include a test to verify the feature or fix and ensure that the feature or fix remains functional.
+
 ## Best Practices
 
 When writing end-to-end tests, test functionality not code. For example, "This page is the color I expect and all 

--- a/3.2-files-directories.md
+++ b/3.2-files-directories.md
@@ -17,3 +17,21 @@ While `/includes/admin/Menu.php` works fine for `\Newfold\WP\Module\Admin\Menu()
 ## WordPress
 
 While we generally follow "the WordPres way," for PSR-4 autoloaded files, we don't use the `class-{name}.php` prefix common in WordPress Core.
+
+### Brand Plugins
+
+We have the plugins setup with `.distignore` and `.distinclude` files which expect certain file organizations. We want our distribution files to be as small as possible but also contain any required files. Following a standard folder structure across our modules will ensure that we have files in proper places for this. To understand these rules please refer to these files in the plugin. They are followed for all build steps locally and via github workflows. For example, any tokens must be ignored in the distributed files and build files for security reasons, thus in the `.distignore` file we ignore all hidden dot files with the line `./*`.
+### Modules
+
+All newfold modules should be setup in a similar directory structure. This makes the files easy to find and simple to target certain files across all modules for the smallest zip file as possible. For example, we don't need to include source javascript files, test files, or even config files in plugins, since those files arent used in this context and only end up taking up space. When a plugin is on hundreds of thousands of sites, this filesize discrepancy adds up quickly and leads more bandwidth and hosting space. Please follow these guidelines and ensure that any module's required files are included in the final distributed plugin zip.
+#### `/includes`
+
+PHP files in the module beyond the bootstrap file and optionally another base file, should be located in an `/includes` directory. These files should be loaded with autoloading and properly namespaced. 
+
+#### `/src` or `/source`
+
+Source javascript files should be located in a `/src` or preferably `/source` directory. According to the plugin level `.distignore` file, these source javascript files will not be included in the distributed plugin zip. If the module requires a build step the compiled javascript in the build directory will be included, but a build javascript step will likely lead to an npmjs or npm.pkg.github package. 
+
+#### `/static`
+
+Any static files (such as images or css) should be placed in a `/static` directory (also acceptable is `/assets`) to ensure they are included in distribution zips.


### PR DESCRIPTION
add section detailing plugin and module directories in the context of distributed files.

This clarifies how modules directories should be organized. It is related to the recent updates in brand plugin distignore and distinclude files.