### PR TITLE
Add Translation Workflow Guide to how-we-work Repository

### DIFF
--- a/5.12-crowdin-translation-workflow.md
+++ b/5.12-crowdin-translation-workflow.md
@@ -1,0 +1,60 @@
+---
+title: Crowdin Translation Workflow Guide
+---
+
+# Translation Workflow Guide
+
+This document outlines the process for managing translations in our WordPress plugin module repositories using Crowdin and GitHub Actions.
+
+## Workflow Overview
+
+Our translation process consists of two GitHub Actions workflows:
+1. **Crowdin Upload Action**: Uploads the latest source file (`.pot` file) to Crowdin.
+2. **Crowdin Download Action**: Downloads translated `.po` files from Crowdin and creates a pull request against the selected branch.
+
+After downloading the translations, additional steps are required to generate the necessary translation files for PHP and JavaScript.
+
+## Steps for Managing Translations
+
+### 1. Upload Source File to Crowdin
+If there are untranslated strings, follow these steps to upload the updated source file to Crowdin:
+
+1. Navigate to the **GitHub repository**.
+2. Go to the **Actions** tab.
+3. Select **Crowdin Upload Action**.
+4. Click **Run workflow** (ensure you are in the correct branch).
+5. The workflow will upload the updated `.pot` file to Crowdin.
+
+### 2. Translate in Crowdin
+1. Log in to [Crowdin](https://crowdin.com/).
+2. Navigate to the respective project.
+3. Use **machine translations** or **manual translations** to complete the missing translations.
+4. Ensure translations are reviewed and approved.
+
+### 3. Download Translations from Crowdin
+Once translations are completed in Crowdin, follow these steps to download the translated `.po` files:
+
+1. Navigate to the **GitHub repository**.
+2. Go to the **Actions** tab.
+3. Select **Crowdin Download Action**.
+4. Click **Run workflow**.
+5. Specify the **base branch** where you want the PR to be raised (default: `main`).
+6. The workflow will download translations and create a pull request.
+
+### 4. Verify and Generate Translation Files
+After the pull request is created:
+1. **Review the translations** in the `.po` files for accuracy and correctness.
+2. Once verified, **merge the pull request**.
+3. Run the following commands to generate translation files for PHP and JS:
+   ```sh
+   composer i18n-mo
+   composer i18n-php
+   composer i18n-json
+   ```
+4. Commit and push the generated files if necessary.
+
+## Notes
+- Ensure that the necessary **Crowdin API credentials** are configured in the repository secrets (`CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN`).
+
+By following this workflow, we can efficiently manage and maintain translations for our WordPress plugin modules.
+

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ This document organizes how we work at Newfold Digital on WordPress and WordPres
 
 #### 5.11 [WordPress Tools & Services](5.11-tools-services.md)
 
+#### 5.12 [Crowdin Translation Workflow](5.12-crowdin-translation-workflow.md)
+
 ### 6. [Laravel](6-laravel.md)
 
 ### 7. [Philosophy](7-philosophy.md)


### PR DESCRIPTION
## Proposed changes

This PR adds a detailed guide on managing translations using Crowdin and GitHub Actions. The guide provides step-by-step instructions on uploading source files, translating via Crowdin, downloading translations, and generating necessary translation files.